### PR TITLE
Update build status badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status]([![Java CI](https://github.com/AY2526S1-CS2103T-F10-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S1-CS2103T-F10-2/tp/actions/workflows/gradle.yml)
+[![CI Status](https://github.com/AY2526S1-CS2103T-F10-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S1-CS2103T-F10-2/tp/actions/workflows/gradle.yml)
 [![codecov](https://codecov.io/gh/AY2526S1-CS2103T-F10-2/tp/branch/master/graph/badge.svg?token=UAX1HBG4BO)](https://codecov.io/gh/AY2526S1-CS2103T-F10-2/tp)
 
 ![Ui](docs/images/Ui.png)


### PR DESCRIPTION
Change the GitHub Actions build status badge to point to the team repository instead of the template. This ensures the badge accurately reflects the build status of the current project.