### PR TITLE
Implement ListByCourseCommand to filter list by course

### DIFF
--- a/src/main/java/seedu/coursebook/logic/Messages.java
+++ b/src/main/java/seedu/coursebook/logic/Messages.java
@@ -19,7 +19,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_SINGLE_COURSE_ONLY = "Only one course can be listed at a time.\n" + ListByCourseCommand.MESSAGE_USAGE;
+    public static final String MESSAGE_SINGLE_COURSE_ONLY =
+                "Only one course can be listed at a time.\n" + ListByCourseCommand.MESSAGE_USAGE;
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/coursebook/logic/Messages.java
+++ b/src/main/java/seedu/coursebook/logic/Messages.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import seedu.coursebook.logic.commands.ListByCourseCommand;
 import seedu.coursebook.logic.parser.Prefix;
 import seedu.coursebook.model.person.Person;
 
@@ -18,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_SINGLE_COURSE_ONLY = "Only one course can be listed at a time.\n" + ListByCourseCommand.MESSAGE_USAGE;
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/coursebook/logic/commands/ListByCourseCommand.java
+++ b/src/main/java/seedu/coursebook/logic/commands/ListByCourseCommand.java
@@ -1,15 +1,22 @@
 package seedu.coursebook.logic.commands;
-import seedu.coursebook.model.Model;
-import seedu.coursebook.model.person.Person;
 
 import static java.util.Objects.requireNonNull;
+
 import java.util.function.Predicate;
 
+import seedu.coursebook.model.Model;
+import seedu.coursebook.model.person.Person;
 /**
  * Lists all persons in the given course in the course book to the user.
  * The command filters only the contacts in the given course and shows them.
  */
 public class ListByCourseCommand extends Command {
+    public static final String COMMAND_WORD = "list";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons enrolled in the specified course.\n"
+            + "Parameters: c/COURSE_NAME\n"
+            + "Example: " + COMMAND_WORD + " c/CS2103T";
+
     private final String course;
 
     /**
@@ -17,16 +24,9 @@ public class ListByCourseCommand extends Command {
      *
      * @param course The course code to filter the contacts with.
      */
-    public ListByCourseCommand(String course){
+    public ListByCourseCommand(String course) {
         this.course = course;
     }
-
-    public static final String COMMAND_WORD = "list";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons enrolled in the specified course.\n"
-            + "Parameters: c/COURSE_NAME\n"
-            + "Example: " + COMMAND_WORD + " c/CS2103T";
-
 
     /**
      * Executes the command by filtering the contacts list to include only those
@@ -39,14 +39,16 @@ public class ListByCourseCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        Predicate<Person> PREDICATE_SHOW_PERSONS_IN_COURSE= person -> person.getCourses().stream().map(c -> c.courseCode).anyMatch(code ->code.equalsIgnoreCase(course));
-        model.updateFilteredPersonList(PREDICATE_SHOW_PERSONS_IN_COURSE);
+        Predicate<Person> personsInCourse = person ->
+                person.getCourses().stream()
+                        .map(c -> c.courseCode)
+                        .anyMatch(code ->code.equalsIgnoreCase(course));
+        model.updateFilteredPersonList(personsInCourse);
         int size = model.getFilteredPersonList().size();
 
-        if(size == 0){
+        if (size == 0) {
             return new CommandResult("No such course: " + course);
-        }
-        else {
+        } else {
             return new CommandResult("Listed all persons in " + course);
         }
     }

--- a/src/main/java/seedu/coursebook/logic/commands/ListByCourseCommand.java
+++ b/src/main/java/seedu/coursebook/logic/commands/ListByCourseCommand.java
@@ -1,0 +1,53 @@
+package seedu.coursebook.logic.commands;
+import seedu.coursebook.model.Model;
+import seedu.coursebook.model.person.Person;
+
+import static java.util.Objects.requireNonNull;
+import java.util.function.Predicate;
+
+/**
+ * Lists all persons in the given course in the course book to the user.
+ * The command filters only the contacts in the given course and shows them.
+ */
+public class ListByCourseCommand extends Command {
+    private final String course;
+
+    /**
+     * Constructs a {@code ListByCourseCommand} with the given course code.
+     *
+     * @param course The course code to filter the contacts with.
+     */
+    public ListByCourseCommand(String course){
+        this.course = course;
+    }
+
+    public static final String COMMAND_WORD = "list";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons enrolled in the specified course.\n"
+            + "Parameters: c/COURSE_NAME\n"
+            + "Example: " + COMMAND_WORD + " c/CS2103T";
+
+
+    /**
+     * Executes the command by filtering the contacts list to include only those
+     * enrolled in the given course. Returns a {@code CommandResult} with feedback.
+     *
+     * @param model The model containing the person list and filtering condition.
+     * @return A {@code CommandResult} indicating the outcome of the command.
+     */
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        Predicate<Person> PREDICATE_SHOW_PERSONS_IN_COURSE= person -> person.getCourses().stream().map(c -> c.courseCode).anyMatch(code ->code.equalsIgnoreCase(course));
+        model.updateFilteredPersonList(PREDICATE_SHOW_PERSONS_IN_COURSE);
+        int size = model.getFilteredPersonList().size();
+
+        if(size == 0){
+            return new CommandResult("No such course: " + course);
+        }
+        else {
+            return new CommandResult("Listed all persons in " + course);
+        }
+    }
+}

--- a/src/main/java/seedu/coursebook/logic/parser/CourseBookParser.java
+++ b/src/main/java/seedu/coursebook/logic/parser/CourseBookParser.java
@@ -2,6 +2,7 @@ package seedu.coursebook.logic.parser;
 
 import static seedu.coursebook.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.coursebook.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.coursebook.logic.parser.CliSyntax.PREFIX_COURSE;
 
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -17,6 +18,7 @@ import seedu.coursebook.logic.commands.EditCommand;
 import seedu.coursebook.logic.commands.ExitCommand;
 import seedu.coursebook.logic.commands.FindCommand;
 import seedu.coursebook.logic.commands.HelpCommand;
+import seedu.coursebook.logic.commands.ListByCourseCommand;
 import seedu.coursebook.logic.commands.ListCommand;
 import seedu.coursebook.logic.commands.RemoveCourseCommand;
 import seedu.coursebook.logic.parser.exceptions.ParseException;
@@ -71,7 +73,19 @@ public class CourseBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(arguments, PREFIX_COURSE);
+            if (argMultimap.getValue(PREFIX_COURSE).isPresent()) {
+                return new ListByCourseCommandParser().parse(arguments);
+            }
+
+            else if(arguments.trim().isEmpty()) {
+                return new ListCommand();
+            }
+
+            else{
+                throw new ParseException("Invalid command format.\n" + ListByCourseCommand.MESSAGE_USAGE);
+            }
+
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/coursebook/logic/parser/CourseBookParser.java
+++ b/src/main/java/seedu/coursebook/logic/parser/CourseBookParser.java
@@ -76,16 +76,11 @@ public class CourseBookParser {
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(arguments, PREFIX_COURSE);
             if (argMultimap.getValue(PREFIX_COURSE).isPresent()) {
                 return new ListByCourseCommandParser().parse(arguments);
-            }
-
-            else if(arguments.trim().isEmpty()) {
+            } else if (arguments.trim().isEmpty()) {
                 return new ListCommand();
-            }
-
-            else{
+            } else {
                 throw new ParseException("Invalid command format.\n" + ListByCourseCommand.MESSAGE_USAGE);
             }
-
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/coursebook/logic/parser/ListByCourseCommandParser.java
+++ b/src/main/java/seedu/coursebook/logic/parser/ListByCourseCommandParser.java
@@ -34,13 +34,16 @@ public class ListByCourseCommandParser implements Parser<ListByCourseCommand> {
         }
 
         // must have only one c/
-        if (argMultimap.getAllValues(PREFIX_COURSE).size()>1) {
+        if (argMultimap.getAllValues(PREFIX_COURSE).size() > 1) {
             throw new ParseException(String.format(MESSAGE_SINGLE_COURSE_ONLY, ListByCourseCommand.MESSAGE_USAGE));
         }
 
         Course courseToSearch = ParserUtil.parseCourse(
                 argMultimap.getValue(PREFIX_COURSE)
-                        .orElseThrow(() -> new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListByCourseCommand.MESSAGE_USAGE)))
+                        .orElseThrow(() -> new ParseException(
+                                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListByCourseCommand.MESSAGE_USAGE)
+                                )
+                        )
         );
 
         return new ListByCourseCommand(courseToSearch.courseCode);

--- a/src/main/java/seedu/coursebook/logic/parser/ListByCourseCommandParser.java
+++ b/src/main/java/seedu/coursebook/logic/parser/ListByCourseCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.coursebook.logic.parser;
+
+import static seedu.coursebook.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.coursebook.logic.Messages.MESSAGE_SINGLE_COURSE_ONLY;
+import static seedu.coursebook.logic.parser.CliSyntax.PREFIX_COURSE;
+
+import seedu.coursebook.logic.commands.ListByCourseCommand;
+import seedu.coursebook.logic.parser.exceptions.ParseException;
+import seedu.coursebook.model.course.Course;
+
+/**
+ * Parses all the input arguments and creates a new {@code ListByCourseCommand} object.
+ * It expects a single {@code c/COURSE_NAME} prefix and validates that
+ * only one course is provided.
+ */
+public class ListByCourseCommandParser implements Parser<ListByCourseCommand> {
+
+    /**
+     * Parses the given arguments and returns a
+     * {@code ListByCourseCommand} object for execution.
+     *
+     * @param args User input arguments following the {@code list} command.
+     * @return A {@code ListByCourseCommand} that filters persons by the specified course.
+     * @throws ParseException If the input does not contain a valid course prefix,
+     *                        contains multiple courses or fails to parse the course.
+     */
+    public ListByCourseCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_COURSE);
+
+        // must have at least one c/
+        if (argMultimap.getAllValues(PREFIX_COURSE).isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListByCourseCommand.MESSAGE_USAGE));
+        }
+
+        // must have only one c/
+        if (argMultimap.getAllValues(PREFIX_COURSE).size()>1) {
+            throw new ParseException(String.format(MESSAGE_SINGLE_COURSE_ONLY, ListByCourseCommand.MESSAGE_USAGE));
+        }
+
+        Course courseToSearch = ParserUtil.parseCourse(
+                argMultimap.getValue(PREFIX_COURSE)
+                        .orElseThrow(() -> new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListByCourseCommand.MESSAGE_USAGE)))
+        );
+
+        return new ListByCourseCommand(courseToSearch.courseCode);
+    }
+}

--- a/src/test/java/seedu/coursebook/logic/commands/ListByCourseCommandTest.java
+++ b/src/test/java/seedu/coursebook/logic/commands/ListByCourseCommandTest.java
@@ -51,4 +51,5 @@ public class ListByCourseCommandTest {
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
+    
 }

--- a/src/test/java/seedu/coursebook/logic/commands/ListByCourseCommandTest.java
+++ b/src/test/java/seedu/coursebook/logic/commands/ListByCourseCommandTest.java
@@ -51,5 +51,4 @@ public class ListByCourseCommandTest {
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
-    
 }

--- a/src/test/java/seedu/coursebook/logic/commands/ListByCourseCommandTest.java
+++ b/src/test/java/seedu/coursebook/logic/commands/ListByCourseCommandTest.java
@@ -1,0 +1,54 @@
+package seedu.coursebook.logic.commands;
+
+import static seedu.coursebook.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.coursebook.testutil.TypicalPersons.getTypicalCourseBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.coursebook.model.Model;
+import seedu.coursebook.model.ModelManager;
+import seedu.coursebook.model.UserPrefs;
+
+/**
+ * Contains tests for ListByCourseCommand.
+ */
+public class ListByCourseCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalCourseBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getCourseBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_courseWithMatches_showsFilteredList() {
+        String courseCode = "CS2103T";
+        ListByCourseCommand command = new ListByCourseCommand(courseCode);
+
+        expectedModel.updateFilteredPersonList(person ->
+                person.getCourses().stream()
+                        .anyMatch(c -> c.courseCode.equalsIgnoreCase(courseCode)));
+
+        String expectedMessage = "Listed all persons in " + courseCode;
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_courseWithNoMatches_showsNoPersonsMessage() {
+        String courseCode = "FakeCourse";
+        ListByCourseCommand command = new ListByCourseCommand(courseCode);
+
+        expectedModel.updateFilteredPersonList(person ->
+                person.getCourses().stream()
+                        .anyMatch(c -> c.courseCode.equalsIgnoreCase(courseCode)));
+
+        String expectedMessage = "No such course: " + courseCode;
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/coursebook/logic/parser/CourseBookParserTest.java
+++ b/src/test/java/seedu/coursebook/logic/parser/CourseBookParserTest.java
@@ -85,7 +85,7 @@ public class CourseBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertThrows(ParseException.class, () -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test


### PR DESCRIPTION
**Summary:**
The ListByCourseCommand allows users to filter contacts based on their enrolled course using the list c/COURSE_NAME syntax. This enhancement improves usability for course-specific queries and aligns with academic use cases.

**Changes Introduced:**
- Added ListByCourseCommand to filter persons by course code.
- Implemented ListByCourseCommandParser with validation for a **single** c/ prefix.
- Updated command usage messages for clarity.
- Added tests.
- Ensured case-insensitive matching of course codes.

**Usage Example:**
list c/CS2103T

Edge Case Handling:
- Rejects multiple c/ prefixes with a clear error message.
- Returns a helpful message when no persons are found in the specified course.

Closes #49 
