### PR TITLE
Enforce no-parameter rule for summary command

### DIFF
--- a/src/main/java/seedu/coursebook/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/coursebook/logic/commands/SummaryCommand.java
@@ -15,6 +15,9 @@ public class SummaryCommand extends Command {
 
     public static final String COMMAND_WORD = "summary";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows a summary of all persons with breakdown by course.";
+
     public static final String MESSAGE_SUCCESS = "Summary: %d person(s) found\n\nBreakdown by course:\n%s";
 
     @Override

--- a/src/main/java/seedu/coursebook/logic/parser/CourseBookParser.java
+++ b/src/main/java/seedu/coursebook/logic/parser/CourseBookParser.java
@@ -92,6 +92,10 @@ public class CourseBookParser {
             }
 
         case SummaryCommand.COMMAND_WORD:
+            if (!arguments.trim().isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        SummaryCommand.MESSAGE_USAGE));
+            }
             return new SummaryCommand();
 
         case ExitCommand.COMMAND_WORD:

--- a/src/test/java/seedu/coursebook/logic/parser/CourseBookParserTest.java
+++ b/src/test/java/seedu/coursebook/logic/parser/CourseBookParserTest.java
@@ -23,6 +23,7 @@ import seedu.coursebook.logic.commands.FindCommand;
 import seedu.coursebook.logic.commands.HelpCommand;
 import seedu.coursebook.logic.commands.ListCommand;
 import seedu.coursebook.logic.commands.ListCoursesCommand;
+import seedu.coursebook.logic.commands.SummaryCommand;
 import seedu.coursebook.logic.commands.ViewCourseCommand;
 import seedu.coursebook.logic.parser.exceptions.ParseException;
 import seedu.coursebook.model.person.NameContainsKeywordsPredicate;
@@ -101,6 +102,18 @@ public class CourseBookParserTest {
         ViewCourseCommand command = (ViewCourseCommand) parser.parseCommand(
                 ViewCourseCommand.COMMAND_WORD + " c/CS2103T");
         assertEquals(new ViewCourseCommand("CS2103T"), command);
+    }
+
+    @Test
+    public void parseCommand_summary() throws Exception {
+        assertTrue(parser.parseCommand(SummaryCommand.COMMAND_WORD) instanceof SummaryCommand);
+    }
+
+    @Test
+    public void parseCommand_summaryWithArguments_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SummaryCommand.MESSAGE_USAGE), ()
+                -> parser.parseCommand(SummaryCommand.COMMAND_WORD + " extra"));
     }
 
     @Test


### PR DESCRIPTION
Previously, the summary command accepted parameters, which was unintended and inconsistent with the expected usage. This change ensures that the summary command now rejects any input parameters.

If parameters are provided, the command outputs an error message indicating an invalid command format. This makes command behavior clearer and prevents user misuse.