### PR TITLE
Fix compilation error in BirthdayCommandTest

### DIFF
--- a/src/test/java/seedu/coursebook/logic/commands/BirthdayCommandTest.java
+++ b/src/test/java/seedu/coursebook/logic/commands/BirthdayCommandTest.java
@@ -19,6 +19,7 @@ import seedu.coursebook.logic.commands.exceptions.CommandException;
 import seedu.coursebook.model.Model;
 import seedu.coursebook.model.ReadOnlyCourseBook;
 import seedu.coursebook.model.ReadOnlyUserPrefs;
+import seedu.coursebook.model.course.Course;
 import seedu.coursebook.model.person.Birthday;
 import seedu.coursebook.model.person.Person;
 import seedu.coursebook.testutil.PersonBuilder;
@@ -122,6 +123,12 @@ public class BirthdayCommandTest {
         }
         @Override public void sortSelectedPersons(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
+        }
+        @Override public ObservableList<Course> getFilteredCourseList() {
+            return FXCollections.observableArrayList();
+        }
+        @Override public void updateFilteredCourseList(Predicate<Course> predicate) {
+
         }
     }
 }


### PR DESCRIPTION
Add missing import for Course and implement two stub methods in ModelStubWithOnePerson to match updated Model interface. Ensure test compiles correctly by providing minimal method implementations for course-related functionality.

- Add import for seedu.coursebook.model.course.Course
- Implement getFilteredCourseList() to return empty list
- Implement updateFilteredCourseList(Predicate<Course>) as empty stub