### PR TITLE
Add reactive course list updates with ListChangeListener

### DIFF
--- a/src/main/java/seedu/coursebook/ui/CourseListPanel.java
+++ b/src/main/java/seedu/coursebook/ui/CourseListPanel.java
@@ -2,6 +2,7 @@ package seedu.coursebook.ui;
 
 import java.util.logging.Logger;
 
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -31,6 +32,18 @@ public class CourseListPanel extends UiPart<Region> {
         this.personList = personList;
         courseListView.setItems(courseList);
         courseListView.setCellFactory(listView -> new CourseListViewCell());
+
+        // Add listener to personList to refresh course cards when persons change
+        personList.addListener((ListChangeListener<Person>) change -> {
+            logger.fine("Person list changed, refreshing course list view");
+            courseListView.refresh();
+        });
+
+        // Also add listener to courseList to handle course additions/removals
+        courseList.addListener((ListChangeListener<Course>) change -> {
+            logger.fine("Course list changed, refreshing course list view");
+            courseListView.refresh();
+        });
     }
 
     /**


### PR DESCRIPTION
Implemented real-time updates for course enrollment counts by adding ListChangeListener listeners to both person and course lists in CourseListPanel.

Previously, enrollment counts refreshed only when users manually interacted with the course list. This change ensures the course list now updates automatically whenever:

A person is added or deleted

A person’s enrolled courses change

A course is added or removed

Using JavaFX’s observable list mechanism improves UI responsiveness and keeps displayed enrollment data consistent with the model state.

Fixes #167