### PR TITLE
find command fix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -214,8 +214,9 @@ Format: `favs`
 ### Finding persons by fields: `find|f`
 
 Finds persons by matching ANY of the provided fields (OR across fields). Within each field, a person matches if ANY of that field’s keywords match.
+Allowed fields are: name, phone, email, address, tag
 
-Format: `find|f [n/NAME_KEYWORDS] [p/PHONE_KEYWORDS] [e/EMAIL_KEYWORDS] [a/ADDRESS_KEYWORDS] [t/TAG]…`
+Format: `find|f [n/NAME_KEYWORDS] [p/PHONE_KEYWORDS] [e/EMAIL_KEYWORDS] [a/ADDRESS_KEYWORDS] [t/TAG]`
 
 Notes:
 
@@ -226,6 +227,7 @@ Notes:
 - All fields (name, phone, email, address, tags) use partial/substring matching (e.g., 'Ali' matches 'Alice', 'fri' matches 'friend' tag).
 - if no prefixes are used, tokens are treated as name keywords .
 - Backwards-compatible: if no prefixes are used, tokens are treated as name keywords (partial match).
+- When searching by names (with or without `n/`), names must contain only alphabets (A–Z).
 
 Examples:
 
@@ -235,6 +237,7 @@ Examples:
 - `find t/fri` (finds persons with tags containing "fri" like "friend")
 - `find n/Alice t/friend` (matches if name contains "Alice" OR has tag containing "friend")
 - `find alex david` (no prefixes → name-only search, partial match)
+  - If no matching contacts are found, the app shows: "No such contact found".
 
 ### Deleting a person : `delete`
 

--- a/src/main/java/seedu/coursebook/logic/Messages.java
+++ b/src/main/java/seedu/coursebook/logic/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_NO_CONTACT_FOUND = "No such contact found";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_SINGLE_COURSE_ONLY =
@@ -27,6 +28,7 @@ public class Messages {
             "Only one birthday can be added to a person.\n" + BirthdayCommand.MESSAGE_USAGE;
     public static final String MESSAGE_SINGLE_ORDER_ONLY =
                 "Sort by only one order at a time.\n" + SortCommand.MESSAGE_USAGE;
+    public static final String MESSAGE_NAME_ALPHA_ONLY = "Names must contain only alphabets";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/coursebook/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/coursebook/logic/commands/FindCommand.java
@@ -20,13 +20,15 @@ public class FindCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds persons by matching any provided field and "
             + "displays them as a list with index numbers.\n"
             + "Parameters: [n/NAME_KEYWORDS] [p/PHONE_KEYWORDS] [e/EMAIL_KEYWORDS] [a/ADDRESS_KEYWORDS] "
-            + "[t/TAG]...\n"
+            + "[t/TAG]\n"
+            + "- Prefixes can appear multiple times; values are aggregated per field (OR within field).\n"
             + "- OR across fields: a person matches if ANY provided field matches.\n"
             + "- Within a field, ANY keyword may match using partial/substring matching.\n"
             + "- All fields support case-insensitive partial matching (e.g., 'Ali' matches 'Alice').\n"
-            + "- If no prefixes are present, input will be treated as a name \n"
+            + "- If no prefixes are present, input will be treated as a name.\n"
+            + "- Only supports prefixes: n/, p/, e/, a/, t/. Any other prefix causes an error.\n"
             + "Alias: f\n"
-            + "Examples: find n/Alice t/friend | find p/9123 e/example.com | find alex bob";
+            + "Examples: find n/John n/Alice | find p/9123 p/9876 | find t/friend t/colleague | find alex bob";
 
     private final PersonContainsKeywordsPredicate predicate;
 
@@ -38,10 +40,11 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
-                false, false, true, false
-        );
+        int count = model.getFilteredPersonList().size();
+        String message = count == 0
+                ? Messages.MESSAGE_NO_CONTACT_FOUND
+                : String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, count);
+        return new CommandResult(message, false, false, true, false);
     }
 
     @Override

--- a/src/main/java/seedu/coursebook/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/coursebook/logic/parser/ArgumentTokenizer.java
@@ -51,7 +51,7 @@ public class ArgumentTokenizer {
         while (prefixPosition != -1) {
             PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
             positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition + 1);
         }
 
         return positions;
@@ -70,9 +70,14 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
+        // Match prefix at start of string
+        if (fromIndex == 0 && argsString.startsWith(prefix)) {
+            return 0;
+        }
+
+        // Match prefix preceded by whitespace
         int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
-        return prefixIndex == -1 ? -1
-                : prefixIndex + 1; // +1 as offset for whitespace
+        return prefixIndex == -1 ? -1 : prefixIndex + 1; // +1 to offset the whitespace
     }
 
     /**

--- a/src/test/java/seedu/coursebook/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/coursebook/logic/commands/FindCommandTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.coursebook.logic.CommandHistory;
+import seedu.coursebook.logic.Messages;
 import seedu.coursebook.model.Model;
 import seedu.coursebook.model.ModelManager;
 import seedu.coursebook.model.UserPrefs;
@@ -58,7 +59,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = Messages.MESSAGE_NO_CONTACT_FOUND;
         PersonContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/coursebook/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/coursebook/logic/parser/FindCommandParserTest.java
@@ -37,4 +37,91 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_unprefixedNonAlpha_throwsParseException() {
+        assertParseFailure(parser, "Alice123", seedu.coursebook.logic.Messages.MESSAGE_NAME_ALPHA_ONLY);
+        assertParseFailure(parser, "Bob-", seedu.coursebook.logic.Messages.MESSAGE_NAME_ALPHA_ONLY);
+        assertParseFailure(parser, "Alice Bob-", seedu.coursebook.logic.Messages.MESSAGE_NAME_ALPHA_ONLY);
+    }
+
+    @Test
+    public void parse_prefixedNameNonAlpha_throwsParseException() {
+        assertParseFailure(parser, "n/Alice123", seedu.coursebook.logic.Messages.MESSAGE_NAME_ALPHA_ONLY);
+        assertParseFailure(parser, "n/Bob- n/Alice", seedu.coursebook.logic.Messages.MESSAGE_NAME_ALPHA_ONLY);
+    }
+
+    @Test
+    public void parse_prefixedOtherFields_allowNonAlpha() {
+        FindCommand expected = new FindCommand(
+                new PersonContainsKeywordsPredicate(
+                        Collections.emptyList(),
+                        Arrays.asList("9123"),
+                        Arrays.asList("alice@example.com"),
+                        Collections.emptyList(),
+                        Collections.emptyList()));
+        assertParseSuccess(parser, "p/9123 e/alice@example.com", expected);
+    }
+
+    @Test
+    public void parse_duplicateNamePrefixes_aggregatesAllValues() {
+        FindCommand expected = new FindCommand(
+                new PersonContainsKeywordsPredicate(
+                        Arrays.asList("John", "Alice"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()));
+        assertParseSuccess(parser, "n/John n/Alice", expected);
+    }
+
+    @Test
+    public void parse_duplicatePhonePrefixes_aggregatesAllValues() {
+        FindCommand expected = new FindCommand(
+                new PersonContainsKeywordsPredicate(
+                        Collections.emptyList(),
+                        Arrays.asList("9123", "9876"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()));
+        assertParseSuccess(parser, "p/9123 p/9876", expected);
+    }
+
+    @Test
+    public void parse_multipleTagPrefixes_stillAggregatesAllValues() {
+        FindCommand expected = new FindCommand(
+                new PersonContainsKeywordsPredicate(
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Arrays.asList("friend", "colleague")));
+        assertParseSuccess(parser, "t/friend t/colleague", expected);
+    }
+
+    @Test
+    public void parse_disallowedKnownPrefixes_throwsParseException() {
+        assertParseFailure(parser, "b/2020-01-01",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "c/CS2103",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "by/name",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_mixedAllowedAndDisallowed_throwsParseException() {
+        assertParseFailure(parser, "n/Alice c/CS2103",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "t/friend z/abc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_unknownPrefix_throwsParseException() {
+        assertParseFailure(parser, "z/foo",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "n/Alice z/foo",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
 }


### PR DESCRIPTION
find now:
-can search multiple fields at once
-can search multiple names as once
-all fields behave similar to tag
-only valid prefixes are allowed, else format error -error messages fixed
-names are enforced to only be made up of alphabets